### PR TITLE
publish v0.8.0

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,32 @@
+name: Clippy
+
+on: [push, pull_request, merge_group]
+
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+  clippy:
+    name: Clippy rust
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: [nightly]
+    steps:
+      - uses: actions/checkout/@v4
+
+      - name: Install Dbus
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: |
+          sudo apt update
+          sudo apt install -y libdbus-1-dev pkg-config
+
+      - name: Install Toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: clippy
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           toolchain: nightly
 
+      - name: Install Dbus
+        run: sudo apt update && sudo apt install libdbus-1-dev pkg-config
+
       - name: Publish crate
         uses: katyo/publish-crates@v2
         with:
@@ -140,7 +143,7 @@ jobs:
           latest_sha=$(git rev-list --tags --max-count=1)
           echo "sha_tag=$latest_sha" >> "$GITHUB_OUTPUT";
 
-      - name: Install dbus
+      - name: Install Dbus
         if: ${{ !matrix.cross && startsWith(matrix.os, 'ubuntu-') }}
         run: sudo apt update && sudo apt install libdbus-1-dev pkg-config
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,25 @@ env:
   PROJECT_NAME: lcode
 
 jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Repository
+        uses: actions/checkout@v4
+
+      - name: Install Nightly Rust Toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+
+      - name: Publish crate
+        uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          ignore-unpublished-changes: true
+
   create-release:
+    needs: [publish]
     runs-on: ubuntu-latest
     steps:
       - name: Release
@@ -25,8 +43,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true
-          # files: |
-          #   ${{ env.BIN_NAME }}-*.zip
           generate_release_notes: true
 
   check-if-bin:
@@ -35,8 +51,10 @@ jobs:
       - name: Fetch Repository
         uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install Nightly Rust Toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
 
       - name: Install jql
         uses: taiki-e/install-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, pull_request, merge_group]
+on: [pull_request, merge_group]
 
 env:
   RUST_BACKTRACE: 1
@@ -31,28 +31,3 @@ jobs:
         run: |
           # cargo nextest run
           cargo test --no-run
-
-  clippy:
-    name: Clippy rust
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [nightly]
-    steps:
-      - uses: actions/checkout/@v4
-
-      - name: Install Dbus
-        if: startsWith(matrix.os, 'ubuntu-')
-        run: |
-          sudo apt update
-          sudo apt install -y libdbus-1-dev pkg-config
-
-      - name: Install Toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-          components: clippy
-
-      - name: Run clippy
-        run: cargo clippy -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2024-04-28
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `reqwest` feature from gzip to brotli.
+- `lcode-config`: change dir name form "leetcode-cn-en-cli" to "lcode".
+
 ## [0.7.18] - 2024-04-22
 
 ### Added
 
-- Edit log file
+- Edit log file.
 
 ### Refactor
 
@@ -24,30 +31,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Check cookies expiry by decrypt-cookies v0.5.3
+- Check cookies expiry by decrypt-cookies v0.5.3.
 
 ## [0.7.16] - 2024-04-18
 
 ### Added
 
-- add helix magic.
+- Add helix magic.
 - `leetcode-api` handle 429 status code frequent.
 
 ### Style
 
-- change question content
+- Change question content.
 
 ## [0.7.15] - 2024-04-09
 
 ### Fixed
 
-- show submit info.
+- Show submit info.
 
 ## [0.7.14] - 2024-04-01
 
 ### Fixed
 
-- update decrypt-cookies 0.5.
+- Update decrypt-cookies 0.5.
 
 ## [0.7.13] - 2024-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- shell completion run `lcode --generate <zsh|bash|...>`
+
 ### Changed
 
 - `reqwest` feature from gzip to brotli.
 - `lcode-config`: change dir name form "leetcode-cn-en-cli" to "lcode".
+- Not auto generate config files, run `lcode gencon` generate default config.
 
 ## [0.7.18] - 2024-04-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,16 +194,16 @@ checksum = "136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928"
 dependencies = [
  "concurrent-queue",
  "event-listener 5.3.0",
- "event-listener-strategy 0.5.1",
+ "event-listener-strategy 0.5.2",
  "futures-core",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-compression"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60"
+checksum = "4e9eabd7a98fe442131a17c316bd9349c43695e49e730c3c8e12cfb5f4da2693"
 dependencies = [
  "brotli",
  "futures-core",
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.7.0"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -467,25 +467,23 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
 dependencies = [
  "async-channel",
  "async-lock 3.3.0",
  "async-task",
- "fastrand 2.0.2",
  "futures-io",
  "futures-lite 2.3.0",
  "piper",
- "tracing",
 ]
 
 [[package]]
 name = "brotli"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125740193d7fee5cc63ab9e16c2fdc4e07c74ba755cc53b327d6ea029e9fc569"
+checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -494,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65622a320492e09b5e0ac436b14c54ff68199bac392d0e89a6832c4518eea525"
+checksum = "e6221fe77a248b9117d431ad93761222e1cf8ff282d9d1d5d9f53d6299a1cf76"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -618,6 +616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1151,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f51cb23d20b0de8458b86580878211da09bcd4503cb579c225b3d124cabb3"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener 5.3.0",
  "pin-project-lite",
@@ -1170,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "flume"
@@ -1776,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "key_parse"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "crossterm 0.27.0",
  "miette",
@@ -1803,10 +1810,11 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lcode"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "atoi",
  "clap",
+ "clap_complete",
  "colored",
  "crossterm 0.27.0",
  "futures",
@@ -1830,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "lcode-config"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "crossterm 0.27.0",
  "decrypt-cookies",
@@ -1845,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "leetcode-api"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "colored",
  "decrypt-cookies",
@@ -1921,9 +1929,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2384,9 +2392,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2394,15 +2402,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -2553,7 +2561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
 dependencies = [
  "atomic-waker",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "futures-io",
 ]
 
@@ -2767,11 +2775,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -2934,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.11"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "ring",
  "rustls-webpki 0.101.7",
@@ -3180,18 +3188,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3426,7 +3434,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "sha2",
@@ -3685,7 +3693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
@@ -3916,7 +3924,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.6",
+ "winnow 0.6.7",
 ]
 
 [[package]]
@@ -4102,9 +4110,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode_categories"
@@ -4550,9 +4558,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,7 +205,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60"
 dependencies = [
- "flate2",
+ "brotli",
  "futures-core",
  "memchr",
  "pin-project-lite",
@@ -229,8 +244,8 @@ dependencies = [
  "futures-io",
  "futures-lite 2.3.0",
  "parking",
- "polling 3.6.0",
- "rustix 0.38.32",
+ "polling 3.7.0",
+ "rustix 0.38.34",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -269,7 +284,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
@@ -286,20 +301,20 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+checksum = "afe66191c335039c7bb78f99dc7520b0cbb166b3a1cb33a03f53d8a1c6f2afda"
 dependencies = [
  "async-io 2.3.2",
- "async-lock 2.8.0",
+ "async-lock 3.3.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -464,6 +479,27 @@ dependencies = [
  "futures-lite 2.3.0",
  "piper",
  "tracing",
+]
+
+[[package]]
+name = "brotli"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125740193d7fee5cc63ab9e16c2fdc4e07c74ba755cc53b327d6ea029e9fc569"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65622a320492e09b5e0ac436b14c54ff68199bac392d0e89a6832c4518eea525"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -696,15 +732,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "crc32fast"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "crossbeam-channel"
@@ -1148,16 +1175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
-name = "flate2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "flume"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,6 +1399,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "h2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,6 +1564,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1647,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "inquire"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe95f33091b9b7b517a5849bce4dce1b550b430fc20d58059fcaa319ed895d8b"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
 dependencies = [
  "bitflags 2.5.0",
  "crossterm 0.25.0",
@@ -1766,7 +1803,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lcode"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "atoi",
  "clap",
@@ -1793,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "lcode-config"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "crossterm 0.27.0",
  "decrypt-cookies",
@@ -1808,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "leetcode-api"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "colored",
  "decrypt-cookies",
@@ -2544,15 +2581,15 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
+checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -2803,6 +2840,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2883,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -2914,7 +2952,7 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.3",
  "subtle",
  "zeroize",
 ]
@@ -2940,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
 
 [[package]]
 name = "rustls-webpki"
@@ -2956,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3266,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -3648,7 +3686,7 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.2",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -3669,7 +3707,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
@@ -3686,18 +3724,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace.package]
 edition      = "2021"
 authors      = ["saying121 <saying121@outlook.com>"]
-homepage     = "https://github.com/saying121/leetcode-cn-en-cli"
+homepage     = "https://github.com/saying121/lcode"
 rust-version = "1.79"
-repository   = "https://github.com/saying121/leetcode-cn-en-cli"
+repository   = "https://github.com/saying121/lcode"
 
 [workspace]
 members  = ["crates/*"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,29 +18,28 @@ codegen-units = 1
 panic         = "abort"
 
 [workspace.dependencies]
-# async
 tokio   = { version = "^1" }
-futures = { version = "^0.3", default_features = false }
+futures = { version = "^0.3", default-features = false }
 
-sea-orm = { version = "^0.12", default_features = false, features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros"] }
+sea-orm = { version = "^0.12", default-features = false, features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros"] }
 
-reqwest = { version = "^0.12", default_features = false, features = ["gzip", "json", "rustls-tls"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "rustls-tls", "brotli", "http2"] }
 
 regex = { version = "^1" }
 
 dirs      = { version = "^5" }
-crossterm = { version = "^0.27", default_features = true, features = ["event-stream"] }
+crossterm = { version = "^0.27", default-features = true, features = ["event-stream"] }
 
 tracing            = { version = "^0.1" }
 tracing-appender   = { version = "^0.2" }
-tracing-subscriber = { version = "^0.3", default_features = true, features = ["env-filter"] }
+tracing-subscriber = { version = "^0.3", default-features = true, features = ["env-filter"] }
 
-miette = { version = "^7", default_features = true }
+miette = { version = "^7", default-features = true }
 
 # Serialize
-serde      = { version = "^1", default_features = false, features = ["derive"] }
-serde_json = { version = "^1", default_features = false }
-toml       = { version = "^0.8", default_features = true }
+serde      = { version = "^1", default-features = false, features = ["derive"] }
+serde_json = { version = "^1", default-features = false }
+toml       = { version = "^0.8", default-features = true }
 
 html2text = { version = "^0" }
 

--- a/KEYMAP.md
+++ b/KEYMAP.md
@@ -9,7 +9,7 @@
 
 ## LOCATION
 
-`~/.config/leetcode-cn-en-cli/keymap.toml`
+`~/.config/lcode/keymap.toml`
 
 ## default Keymap
 

--- a/LANGS.md
+++ b/LANGS.md
@@ -6,7 +6,7 @@
 
 ## LOCATION
 
-`~/.config/leetcode-cn-en-cli/langs.toml`
+`~/.config/lcode/langs.toml`
 
 ## FIELD
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -99,6 +99,16 @@ lcode -h
 lcode fzy <edit>
 ```
 
+Shell 补全.
+
+```bash
+# zsh
+echo 'eval $(lcode --generate zsh)' >>~/.zshrc
+# bash
+echo 'eval $(lcode --generate bash)' >>~/.bashrc
+# ...
+```
+
 ## 视频
 
 <https://github.com/saying121/lcode/assets/74663483/62b8f4cc-73dc-49db-a6a1-4823a640a13a>

--- a/README-CN.md
+++ b/README-CN.md
@@ -57,10 +57,10 @@
 cargo binstall lcode
 ```
 
-- 去 [release](https://github.com/saying121/leetcode-cn-en-cli/releases) 下载
+- 去 [release](https://github.com/saying121/lcode/releases) 下载
 
 [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) 就是从
-[release](https://github.com/saying121/leetcode-cn-en-cli/releases) 下载二进制文件。
+[release](https://github.com/saying121/lcode/releases) 下载二进制文件。
 
 - 自己编译
 
@@ -101,36 +101,36 @@ lcode fzy <edit>
 
 ## 视频
 
-<https://github.com/saying121/leetcode-cn-en-cli/assets/74663483/62b8f4cc-73dc-49db-a6a1-4823a640a13a>
+<https://github.com/saying121/lcode/assets/74663483/62b8f4cc-73dc-49db-a6a1-4823a640a13a>
 
-<https://github.com/saying121/leetcode-cn-en-cli/assets/74663483/9ad6ad58-b401-42f6-b8dc-359f78a37729>
+<https://github.com/saying121/lcode/assets/74663483/9ad6ad58-b401-42f6-b8dc-359f78a37729>
 
 ## 配置
 
 配置位置
 
-- Linux: `~/.config/leetcode-cn-en-cli/`
-- macos: `~/.config/leetcode-cn-en-cli/`
-- Windows: `C:\Users\Alice\AppData\Roaming\`
+- Linux: `~/.config/lcode/`
+- macos: `~/.config/lcode/`
+- Windows: `C:\Users\Alice\AppData\Roaming\lcode`
 
 代码默认位置
 
-- Linux: `~/.local/share/leetcode-cn-en-cli`
-- macOS: `~/Library/Application Support/leetcode-cn-en-cli`
-- Windows: `C:\Users\Alice\AppData\Local\leetcode-cn-en-cli`
+- Linux: `~/.local/share/lcode`
+- macOS: `~/Library/Application Support/lcode`
+- Windows: `C:\Users\Alice\AppData\Local\lcode`
 
 布局:
 ![default](./pictures/screen_shot_.png)
 
 缓存位置
 
-- Linux: `~/.local/share/leetcode-cn-en-cli/`
-- macOS: `~/Library/Caches/leetcode-cn-en-cli`
-- Windows: `C:\Users\user\AppData\Local\leetcode-cn-en-cli`
+- Linux: `~/.local/share/lcode/`
+- macOS: `~/Library/Caches/lcode`
+- Windows: `C:\Users\user\AppData\Local\lcode`
 
 ### Cookies 重要部分
 
-一般来说只需要填写 `~/.config/leetcode-cn-en-cli/config.toml`
+一般来说只需要填写 `~/.config/lcode/config.toml`
 要使用这个选项，注意不要设置关闭浏览器时清空 cookies。
 
 ```toml
@@ -142,7 +142,7 @@ browser = "edge" # `chrome`, `edge`, `firefox`, `librewolf` etc.
 
 ---
 
-`~/.config/leetcode-cn-en-cli/cookies.toml`
+`~/.config/lcode/cookies.toml`
 
 ```toml
 csrf = ""
@@ -187,7 +187,7 @@ num_sublist = 10
 page_size = 25
 editor = ["vim"]
 lang = "rust"
-code_dir = "/home/user/.local/share/leetcode-cn-en-cli"
+code_dir = "/home/user/.local/share/lcode"
 browser = ""
 
 url_suffix = "cn"
@@ -265,13 +265,13 @@ lang = "rust"
 设置代码和测试用例存储的位置
 
 ```toml
-code_dir = "/home/user/.local/share/leetcode-cn-en-cli"
+code_dir = "/home/user/.local/share/lcode"
 ```
 
 也可以这样写，以`~`开头
 
 ```toml
-code_dir = "~/.local/share/leetcode-cn-en-cli"
+code_dir = "~/.local/share/lcode"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ Begin selecting a question.
 lcode fzy <edit>
 ```
 
+Shell completion.
+
+```bash
+# zsh
+echo 'eval $(lcode --generate zsh)' >>~/.zshrc
+# bash
+echo 'eval $(lcode --generate bash)' >>~/.bashrc
+# ...
+```
+
 ## 📼Videos
 
 <https://github.com/saying121/lcode/assets/74663483/57a633e5-6bae-4816-a224-d7d61d2141af>

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ build-dependencies:
 cargo binstall lcode
 ```
 
-- Download from [release](https://github.com/saying121/leetcode-cn-en-cli/releases)
+- Download from [release](https://github.com/saying121/lcode/releases)
 
 In reality, [cargo-binstall](https://github.com/cargo-bins/cargo-binstall)
 is used to download binaries from
-[release](https://github.com/saying121/leetcode-cn-en-cli/releases)
+[release](https://github.com/saying121/lcode/releases)
 
 - Build by yourself
 
@@ -108,38 +108,38 @@ lcode fzy <edit>
 
 ## 📼Videos
 
-<https://github.com/saying121/leetcode-cn-en-cli/assets/74663483/57a633e5-6bae-4816-a224-d7d61d2141af>
+<https://github.com/saying121/lcode/assets/74663483/57a633e5-6bae-4816-a224-d7d61d2141af>
 
-<https://github.com/saying121/leetcode-cn-en-cli/assets/74663483/9ad6ad58-b401-42f6-b8dc-359f78a37729>
+<https://github.com/saying121/lcode/assets/74663483/9ad6ad58-b401-42f6-b8dc-359f78a37729>
 
 ## ⚙️Configuration
 
 The configuration located
 
-- Linux: `~/.config/leetcode-cn-en-cli/`
-- macos: `~/.config/leetcode-cn-en-cli/`
-- Windows: `C:\Users\user\AppData\Roaming\leetcode-cn-en-cli`
+- Linux: `~/.config/lcode/`
+- macos: `~/.config/lcode/`
+- Windows: `C:\Users\user\AppData\Roaming\lcode`
 
 The code default located
 
-- Linux: `~/.local/share/leetcode-cn-en-cli/`
-- macOS: `~/Library/Application Support/leetcode-cn-en-cli`
-- Windows: `C:\Users\user\AppData\Local\leetcode-cn-en-cli`
+- Linux: `~/.local/share/lcode/`
+- macOS: `~/Library/Application Support/lcode`
+- Windows: `C:\Users\user\AppData\Local\lcode`
 
 code layout:
 ![default](./pictures/screen_shot_.png)
 
 The cache located
 
-- Linux: `~/.local/share/leetcode-cn-en-cli/`
-- macOS: `~/Library/Caches/leetcode-cn-en-cli`
-- Windows: `C:\Users\user\AppData\Local\leetcode-cn-en-cli`
+- Linux: `~/.local/share/lcode/`
+- macOS: `~/Library/Caches/lcode`
+- Windows: `C:\Users\user\AppData\Local\lcode`
 
 ### Cookies (Important)
 
 > [**First, login leetcode in browser for generate cookies**]
 
-General you just need filled browser at `~/.config/leetcode-cn-en-cli/config.toml`.
+General you just need filled browser at `~/.config/lcode/config.toml`.
 
 When use the section，be careful not to clear cookies when closing the browser.
 
@@ -152,7 +152,7 @@ The detail: [decrypt-cookies](https://github.com/saying121/tidy-browser/tree/mas
 
 ---
 
-`~/.config/leetcode-cn-en-cli/cookies.toml`
+`~/.config/lcode/cookies.toml`
 
 ```toml
 csrf = ""
@@ -195,7 +195,7 @@ num_sublist = 10
 page_size = 25
 editor = ["vim"]
 lang = "rust"
-code_dir = "/home/user/.local/share/leetcode-cn-en-cli"
+code_dir = "/home/user/.local/share/lcode"
 browser = ""
 
 url_suffix = "com"
@@ -278,9 +278,9 @@ Set the location for storing code and test cases.
 You can also starting with `~`
 
 ```toml
-code_dir = "/home/user/.local/share/leetcode-cn-en-cli"
+code_dir = "/home/user/.local/share/lcode"
 # or
-code_dir = "~/.local/share/leetcode-cn-en-cli"
+code_dir = "~/.local/share/lcode"
 ```
 
 ---

--- a/crates/key_parse/Cargo.toml
+++ b/crates/key_parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "key_parse"
-version      = "0.1.7"
+version      = "0.1.8"
 description  = "parse keymap like neovim"
 license      = "Apache-2.0"
 edition      = { workspace = true }

--- a/crates/key_parse/Cargo.toml
+++ b/crates/key_parse/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["tests/"]
 [dependencies]
 serde     = { workspace = true }
 toml      = { workspace = true }
-crossterm = { version = "^0.27", default_features = false, features = ["events"] }
+crossterm = { version = "^0.27", default-features = false, features = ["events"] }
 miette    = { workspace = true }
 
 [dev-dependencies]

--- a/crates/lcode-config/Cargo.toml
+++ b/crates/lcode-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "lcode-config"
-version      = "0.3.8"
+version      = "0.3.9"
 license      = "MIT OR Apache-2.0"
 description  = "config mod for [lcode](https://crates.io/crates/lcode)"
 edition      = { workspace = true }

--- a/crates/lcode-config/src/config/global.rs
+++ b/crates/lcode-config/src/config/global.rs
@@ -2,12 +2,12 @@ use std::{collections::HashMap, fs::create_dir_all, path::PathBuf, sync::LazyLoc
 
 use super::{read_config::get_user_conf, User};
 
-pub const G_APP_NAME: &str = "leetcode-cn-en-cli";
+pub const G_APP_NAME: &str = "lcode";
 pub const LOG_FILE: &str = "lcode.log";
 
 /// # Get dir path and create dir
 ///
-/// ~/.cache/leetcode-cn-en-cli/
+/// ~/.cache/lcode/
 pub static G_CACHE_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
     let mut log_dir = dirs::cache_dir().expect("new cache dir failed");
     create_dir_all(&log_dir).expect("create cache dir failed");
@@ -25,7 +25,7 @@ pub static G_LOG_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
 pub static G_USER_CONFIG: LazyLock<User> =
     LazyLock::new(|| get_user_conf().expect("get G_USER_CONFIG falied"));
 
-/// "~/.cache/leetcode-cn-en-cli/leetcode.db"
+/// "~/.cache/lcode/leetcode-<cn/com>.db"
 pub static G_DATABASE_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     let mut db_path = G_CACHE_DIR.clone();
     db_path.push(format!("leetcode-{}.db", G_USER_CONFIG.config.url_suffix));
@@ -33,7 +33,7 @@ pub static G_DATABASE_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
 });
 
 /// # Initialize the config directory create dir if not exists
-/// "~/.config/leetcode-cn-en-cli/"
+/// "~/.config/lcode/"
 static G_CONF_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
     #[cfg(not(target_os = "macos"))]
     let mut config_dir = dirs::config_dir().expect("new config dir failed");
@@ -51,7 +51,7 @@ static G_CONF_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
 });
 
 /// # get the config path
-/// "~/.config/leetcode-cn-en-cli/config.toml"
+/// "~/.config/lcode/config.toml"
 pub static G_CONFIG_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     let mut dir = G_CONF_DIR.clone();
     dir.push("config.toml");
@@ -59,7 +59,7 @@ pub static G_CONFIG_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
 });
 
 /// # get the cookies config path
-/// "~/.config/leetcode-cn-en-cli/cookies.toml"
+/// "~/.config/lcode/cookies.toml"
 pub static G_COOKIES_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     let mut dir = G_CONF_DIR.clone();
     dir.push("cookies.toml");
@@ -67,7 +67,7 @@ pub static G_COOKIES_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
 });
 
 /// # get the lang config path
-/// "~/.config/leetcode-cn-en-cli/langs.toml"
+/// "~/.config/lcode/langs.toml"
 pub static G_LANGS_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     let mut dir = G_CONF_DIR.clone();
     dir.push("langs.toml");
@@ -75,7 +75,7 @@ pub static G_LANGS_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
 });
 
 /// # get the keymap config path
-/// "~/.config/leetcode-cn-en-cli/keymap.toml"
+/// "~/.config/lcode/keymap.toml"
 pub static G_KEYMAP_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     let mut dir = G_CONF_DIR.clone();
     dir.push("keymap.toml");

--- a/crates/lcode-config/src/config/user_serializes.rs
+++ b/crates/lcode-config/src/config/user_serializes.rs
@@ -34,7 +34,7 @@ pub(super) fn lang_default() -> String {
     "rust".to_owned()
 }
 
-/// "~/.local/share/leetcode-cn-en-cli"
+/// "~/.local/share/lcode"
 pub(super) fn default_code_dir() -> PathBuf {
     let mut code_dir = dirs::data_local_dir().expect("new data local dir failed");
     code_dir.push(G_APP_NAME);

--- a/crates/lcode-config/src/keymap.rs
+++ b/crates/lcode-config/src/keymap.rs
@@ -79,8 +79,12 @@ impl Hash for KeyMap {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[derive(Serialize, Deserialize)]
+#[derive(PartialEq, Eq)]
+#[derive(Clone)]
+#[derive(Debug)]
 pub struct TuiKeyMap {
+    #[serde(default)]
     pub keymap: HashSet<KeyMap>,
 }
 

--- a/crates/lcode-config/tests/config_work.rs
+++ b/crates/lcode-config/tests/config_work.rs
@@ -6,9 +6,10 @@ use lcode_config::config::global::{
 
 #[test]
 fn glob_path() {
-    dbg!(&G_CONFIG_PATH);
-    dbg!(&G_LANGS_PATH);
-    dbg!(&G_COOKIES_PATH);
+    let home = dirs::home_dir().unwrap();
+    assert_eq!(*G_CONFIG_PATH, home.join(".config/lcode/config.toml"));
+    assert_eq!(*G_LANGS_PATH, home.join(".config/lcode/langs.toml"));
+    assert_eq!(*G_COOKIES_PATH, home.join(".config/lcode/cookies.toml"));
 }
 
 #[test]

--- a/crates/lcode-config/tests/config_work.rs
+++ b/crates/lcode-config/tests/config_work.rs
@@ -33,7 +33,7 @@ fn macos_path() {
                     .unwrap()
                     .to_str()
                     .unwrap(),
-                ".config/leetcode-cn-en-cli/config.toml"
+                ".config/lcode/config.toml"
             )
         );
     }

--- a/crates/lcode/Cargo.toml
+++ b/crates/lcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "lcode"
-version       = "0.7.18"
+version       = "0.7.19"
 description   = "An application of terminal write leetcode.一个终端刷力扣的应用"
 documentation = "https://docs.rs/lcode"
 license       = "Apache-2.0"
@@ -40,6 +40,7 @@ inquire        = { version = "^0.7", default-features = false, features = ["macr
 atoi           = { version = "^2" }
 unicode-width  = { version = "^0.1" }
 
+clap_complete = { version = "^4" }
 clap = { version = "^4", default-features = false, features = [
     "derive",
     "std",

--- a/crates/lcode/Cargo.toml
+++ b/crates/lcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "lcode"
-version       = "0.7.19"
+version       = "0.8.0"
 description   = "An application of terminal write leetcode.一个终端刷力扣的应用"
 documentation = "https://docs.rs/lcode"
 license       = "Apache-2.0"

--- a/crates/lcode/Cargo.toml
+++ b/crates/lcode/Cargo.toml
@@ -36,11 +36,11 @@ tracing-subscriber = { workspace = true }
 # nucleo = { version = "0.4.0" }
 # nucleo-matcher = { version = "0.3.1" }
 simsearch      = { version = "^0.2" }
-inquire        = { version = "^0.7", default_features = false, features = ["macros", "crossterm", "fuzzy"] }
+inquire        = { version = "^0.7", default-features = false, features = ["macros", "crossterm", "fuzzy"] }
 atoi           = { version = "^2" }
 unicode-width  = { version = "^0.1" }
 
-clap = { version = "^4", default_features = false, features = [
+clap = { version = "^4", default-features = false, features = [
     "derive",
     "std",
     "help",
@@ -56,8 +56,8 @@ crossterm    = { workspace = true }
 tui-textarea = { version = "^0.4" }
 
 # Shit, decode leetcode avator error: `InvalidSignature`
-# ratatui-image = { version = "^1", default_features = true }
-# image         = { version = "^0.24", default_features = true, features = ["png", "gif", "jpeg"] }
+# ratatui-image = { version = "^1", default-features = true }
+# image         = { version = "^0.24", default-features = true, features = ["png", "gif", "jpeg"] }
 
 # tui-term = { version = "0.1.2" }
 # tui-logger = { version = "0.9.5" }
@@ -66,7 +66,7 @@ open = { version = "^5" }
 
 rayon = { version = "^1" }
 
-notify-rust = { version = "^4.10", default_features = false, features = ["d"] }
+notify-rust = { version = "^4.10", default-features = false, features = ["d"] }
 
 lcode-config = { workspace = true }
 leetcode-api = { workspace = true }

--- a/crates/lcode/src/cli.rs
+++ b/crates/lcode/src/cli.rs
@@ -11,14 +11,16 @@ use crate::{
     glob_leetcode, mytui,
 };
 
-#[derive(Debug, Parser)]
+#[derive(Debug)]
+#[derive(Parser)]
 #[command(version, about)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug)]
+#[derive(Subcommand)]
 enum Commands {
     #[command(
         alias = "e",
@@ -57,27 +59,31 @@ enum Commands {
     Star,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug)]
+#[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 struct GenArgs {
     #[arg(short, long)]
     cn: bool,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug)]
+#[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 struct SubTestArgs {
     id: u32,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug)]
+#[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 struct InterArgs {
     #[command(subcommand)]
     command: Option<DetailOrEdit>,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug)]
+#[derive(Subcommand)]
 enum DetailOrEdit {
     #[command(about = "View detail")]
     Detail(DetailArgs),
@@ -85,7 +91,8 @@ enum DetailOrEdit {
     Edit,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug)]
+#[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 struct DetailArgs {
     #[arg(help = "Force update question's information")]
@@ -94,14 +101,16 @@ struct DetailArgs {
     force: bool,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug)]
+#[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 struct Force {
     #[arg(short, long, help = "Delete database for full re-sync")]
     force: bool,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug)]
+#[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 struct EditArgs {
     #[command(subcommand)]
@@ -111,7 +120,8 @@ struct EditArgs {
     id: Option<EditCodeArgs>,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug)]
+#[derive(Subcommand)]
 enum CoT {
     #[command(about = "Edit code(default)")]
     Code(EditCodeArgs),
@@ -119,7 +129,8 @@ enum CoT {
     Test(EditCodeArgs),
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug)]
+#[derive(Args)]
 #[command(args_conflicts_with_subcommands = true)]
 struct EditCodeArgs {
     #[arg(help = "Question id")]

--- a/crates/lcode/src/lib.rs
+++ b/crates/lcode/src/lib.rs
@@ -8,7 +8,7 @@ pub mod mytui;
 pub mod panic_hook;
 
 pub fn star() {
-    open::that_detached("https://github.com/saying121/leetcode-cn-en-cli").unwrap_or_default();
+    open::that_detached("https://github.com/saying121/lcode").unwrap_or_default();
 }
 
 pub use leetcode_api::glob_leetcode;

--- a/crates/lcode/src/panic_hook.rs
+++ b/crates/lcode/src/panic_hook.rs
@@ -33,7 +33,8 @@ pub fn init_panic_hook() {
             .with(file_layer)
             .init();
 
-        tracing::error!("Panic Error: {}", panic);
+        tracing::info!("View the log by `lcode L`.");
+        tracing::error!("Error: {}", panic);
 
         Term::stop().expect("term stop failed");
 

--- a/crates/leetcode-api/Cargo.toml
+++ b/crates/leetcode-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "leetcode-api"
-version      = "0.3.14"
+version      = "0.3.15"
 description  = "leetcode api"
 license      = "MIT"
 edition      = { workspace = true }

--- a/crates/leetcode-api/Cargo.toml
+++ b/crates/leetcode-api/Cargo.toml
@@ -36,7 +36,7 @@ strum = { version = "^0.26" }
 # render
 html2text            = { workspace = true }
 scraper              = { version = "^0.19" }
-tabled               = { version = "^0.15", default_features = true }
+tabled               = { version = "^0.15", default-features = true }
 
 lcode-config    = { workspace = true }
 decrypt-cookies = { workspace = true }

--- a/crates/leetcode-api/src/leetcode/mod.rs
+++ b/crates/leetcode-api/src/leetcode/mod.rs
@@ -62,7 +62,7 @@ impl LeetCode {
     /// Create a `LeetCode` instance and initialize some variables
     pub async fn build() -> Result<Self> {
         let client = ClientBuilder::new()
-            .gzip(true)
+            .brotli(true)
             .connect_timeout(Duration::from_secs(30))
             .build()
             .into_diagnostic()

--- a/crates/leetcode-api/tests/build_header_work.rs
+++ b/crates/leetcode-api/tests/build_header_work.rs
@@ -1,7 +1,7 @@
 use leetcode_api::leetcode::headers::Headers;
 
 #[tokio::test]
-async fn get_cookies_work() {
+async fn build_header_work() {
     let var = Headers::build("leetcode.cn")
         .await
         .unwrap();

--- a/crates/leetcode-api/tests/query_work.rs
+++ b/crates/leetcode-api/tests/query_work.rs
@@ -1,4 +1,4 @@
-use leetcode_api::dao::query::*;
+use leetcode_api::{dao::query::*, entities::topic_tags};
 use miette::Result;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -35,7 +35,7 @@ async fn query_count() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn query_all_topic_tags() -> Result<()> {
-    let alltop: Vec<leetcode_api::entities::topic_tags::Model> = Query::query_all_topic().await?;
+    let alltop: Vec<topic_tags::Model> = Query::query_all_topic().await?;
 
     assert!(alltop.len() > 70);
 


### PR DESCRIPTION
### Added

- shell completion run `lcode --generate <zsh|bash|...>`

### Changed

- `reqwest` feature from gzip to brotli.
- `lcode-config`: change dir name form "leetcode-cn-en-cli" to "lcode".
- Not auto generate config files, run `lcode gencon` generate default config.

### migration to v0.8.0

```bash
# linux
cp -r ~/.config/leetcode-cn-en-cli ~/.config/lcode
cp -r ~/.cache/leetcode-cn-en-cli ~/.cache/lcode
# macos
cp -r ~/.config/leetcode-cn-en-cli ~/.config/lcode
cp -r ~/Library/Caches/leetcode-cn-en-cli ~/Library/Caches/lcode
```
